### PR TITLE
Use fork of ja_serializer to fix compile errors.

### DIFF
--- a/server/mix.exs
+++ b/server/mix.exs
@@ -35,6 +35,6 @@ defmodule BdPro.Mixfile do
      {:phoenix_html, "~> 2.1"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:cowboy, "~> 1.0"},
-     {:ja_serializer, "~> 0.3.0"}]
+     {:ja_serializer, github: "st23am/ja_serializer"}]
   end
 end

--- a/server/mix.lock
+++ b/server/mix.lock
@@ -4,7 +4,7 @@
   "ecto": {:hex, :ecto, "1.0.1"},
   "fs": {:hex, :fs, "0.9.2"},
   "inflex": {:hex, :inflex, "1.4.1"},
-  "ja_serializer": {:hex, :ja_serializer, "0.3.0"},
+  "ja_serializer": {:git, "git://github.com/st23am/ja_serializer.git", "e2b039b6cf2785c9dce7dd758d4e8fbc981168ec", []},
   "phoenix": {:hex, :phoenix, "1.0.1"},
   "phoenix_ecto": {:hex, :phoenix_ecto, "1.2.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.2.0"},


### PR DESCRIPTION
JaDeserializer does a check to make sure Plug is loaded which may not be 
true at compile time. This was causing compilation problems during 
deployment.

Offending line: https://github.com/AgilionApps/ja_serializer/blob/master/lib/ja_serializer/deserializer.ex#L1

It may not make sense for Plug to be a optional dependency for ja_serializer but, we'll have to fix that upstream with a pull request.
